### PR TITLE
Add nntin/discord-logo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendor/discord-bots/vbe0201/Vale.py"]
 	path = vendor/discord-bots/vbe0201/Vale.py
 	url = https://github.com/vbe0201/Vale.py.git
+[submodule "vendor/miscellaneous/nntin/discord-logo"]
+	path = vendor/miscellaneous/nntin/discord-logo
+	url = https://github.com/nntin/discord-logo.git

--- a/categories.sh
+++ b/categories.sh
@@ -7,4 +7,5 @@
 CATS=(
     "api-wrappers" \
     "discord-bots" \
+    "miscellaneous" \
 )

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Every repository below is also listed as git submodule in [**vendor**](vendor/).
 ## API Wrapper
 *Libraries for easy-accessing APIs in different languages*
 
-- [Shitcord](https://github.com/vbe0201/Shitcord) `[Python]` - A shitty, probably not even that shitty Discord API wrapper. 
+- [Shitcord](https://github.com/vbe0201/Shitcord) `[Python]` - A shitty, probably not even that shitty Discord API wrapper.
 
 ## Discord Bots
 *Bots using the Discord API.*
@@ -29,3 +29,8 @@ Every repository below is also listed as git submodule in [**vendor**](vendor/).
 - [MemberCounter](https://github.com/error2507/MemberCounter) `[NodeJS]` - Counts guild members and displays it per-guild as nickname.
 - [shinpuru](https://github.com/zekroTJA/shinpuru) `[Go]` - General moderation and management bot, also managing zekro's Dev Discord.
 - [Vale.py](https://github.com/vbe0201/Vale.py) `[Python]` - General purpose and fun discord bot.
+
+## Miscellaneous
+*Other Discord-related projects*
+
+- [discord-logo](https://github.com/NNTin/discord-logo) `[html, js, css]` An animated discord logo generator using SVG.

--- a/readme.md
+++ b/readme.md
@@ -33,4 +33,4 @@ Every repository below is also listed as git submodule in [**vendor**](vendor/).
 ## Miscellaneous
 *Other Discord-related projects*
 
-- [discord-logo](https://github.com/NNTin/discord-logo) `[html, js, css]` An animated discord logo generator using SVG.
+- [discord-logo](https://github.com/NNTin/discord-logo) `[html, js, css]` - An animated discord logo generator using SVG.


### PR DESCRIPTION
I'm not sure about the quality standard of nntin/discord-logo. It was my first website and I was playing around with it.

Use case of this project is if you own a website you could embed animated Discord button somewhere. You could also add a Discord corner button, similar to GitHub corners/ribbons.